### PR TITLE
Rebrand KibaOS to KibaTV and switch to KDE Plasma Bigscreen

### DIFF
--- a/.github/workflows/kiba.yml
+++ b/.github/workflows/kiba.yml
@@ -1,0 +1,423 @@
+name: "KibaTV Build"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create build script
+        run: |
+          cat > build.sh << 'BUILD_SCRIPT_EOF'
+          #!/bin/bash
+          set -ex
+          export DEBIAN_FRONTEND=noninteractive
+
+          # ── Install live-build and build deps ─────────────────────────────────────
+          apt update && apt install -y \
+            live-build debootstrap xorriso git squashfs-tools \
+            grub-efi-amd64-bin grub-pc-bin mtools dosfstools \
+            qemu-system-x86 \
+            meson ninja-build pkg-config \
+            libgtk-4-dev libadwaita-1-dev libflatpak-dev libappstream-dev \
+            libjson-glib-dev libostree-dev \
+            gcc g++ gettext
+
+          cd /w
+          ISO="kibatv-v${RUN_NUM}"
+
+          echo "=== Configuring live-build ==="
+
+          lb config \
+            --distribution trixie \
+            --architectures amd64 \
+            --archive-areas "main contrib non-free non-free-firmware" \
+            --debian-installer live \
+            --debian-installer-gui false \
+            --binary-images iso-hybrid \
+            --mode debian \
+            --system live \
+            --linux-flavours amd64 \
+            --linux-packages "linux-image linux-headers" \
+            --bootappend-live "boot=live components quiet splash console=ttyS0" \
+            --bootappend-install "auto=true priority=critical" \
+            --bootloaders "grub-pc,grub-efi" \
+            --iso-application "KibaTV" \
+            --iso-volume "KIBATV" \
+            --cache true \
+            --cache-packages true \
+            --cache-stages "bootstrap chroot rootfs binary" \
+            --apt-options "--yes --no-install-recommends" \
+            --apt-recommends false \
+            --apt-indices false \
+            --debootstrap-options "--variant=minbase --exclude=nano,vim-tiny,info" \
+            --firmware-chroot false \
+            --memtest none \
+            --compression xz \
+            --chroot-squashfs-compression-type zstd \
+            --chroot-squashfs-compression-level 19
+
+          # ── Starship prompt hook ────────────────────────────────────────────
+          mkdir -p config/hooks/live
+          cat > config/hooks/live/0030-starship.hook.chroot << 'STARSHIP_HOOK'
+          #!/bin/bash
+          set -e
+          echo "=== Configuring Starship Prompt ==="
+
+          # Branded starship config
+          mkdir -p /etc/skel/.config
+          cat > /etc/skel/.config/starship.toml << 'STARSHIP_CONF'
+          format = "$all"
+          add_newline = false
+
+          [character]
+          success_symbol = "[❯](bold #bd93f9)"
+          error_symbol = "[❯](bold #ff5555)"
+
+          [directory]
+          style = "bold #bd93f9"
+
+          [git_branch]
+          symbol = "󰊢 "
+          style = "bold #50fa7b"
+
+          [hostname]
+          ssh_only = false
+          format = "[$hostname]($style) "
+          style = "bold #bd93f9"
+
+          [username]
+          show_always = true
+          format = "[$user]($style)@"
+          style = "bold #bd93f9"
+          STARSHIP_CONF
+
+          echo "=== Starship Prompt configured ==="
+          STARSHIP_HOOK
+          chmod +x config/hooks/live/0030-starship.hook.chroot
+
+          # ── Extreme Minimization hook ───────────────────────────────────────
+          cat > config/hooks/live/0090-extreme-minimization.hook.chroot << 'MIN_HOOK'
+          #!/bin/bash
+          set -e
+          echo "=== Aggressive Minimization: cleaning system ==="
+
+          # 1. Remove all documentation, man pages, and info files
+          rm -rf /usr/share/doc/*
+          rm -rf /usr/share/man/*
+          rm -rf /usr/share/info/*
+          rm -rf /usr/share/help/*
+
+          # 2. Remove all locales except en and en_US
+          find /usr/share/locale -mindepth 1 -maxdepth 1 ! -name 'en' ! -name 'en_US' -exec rm -rf {} +
+
+          # 3. Clean apt cache and lists
+          rm -rf /var/cache/apt/archives/*
+          rm -rf /var/lib/apt/lists/*
+
+          # 4. Remove temporary files
+          rm -rf /tmp/* /var/tmp/*
+
+          echo "=== Aggressive Minimization complete ==="
+          MIN_HOOK
+          chmod +x config/hooks/live/0090-extreme-minimization.hook.chroot
+
+          # ── GRUB branding + user-friendly boot menu ─────────────────────────
+          mkdir -p config/hooks/binary
+          cat > config/hooks/binary/0020-bootloader-branding.hook.binary << 'BOOT_HOOK'
+          #!/bin/bash
+          set -e
+          echo "=== Patching GRUB boot menu ==="
+
+          # Find all grub.cfg files in the binary directory
+          GRUB_CONFIGS=$(find binary -name "grub.cfg")
+
+          if [ -n "$GRUB_CONFIGS" ]; then
+            for cfg in $GRUB_CONFIGS; do
+              echo "  Patched: $cfg"
+              sed -i \
+                -e 's/Debian GNU\/Linux/KibaTV/g' \
+                -e 's/Debian Live/KibaTV/g' \
+                -e 's/GNU\/Linux Live/KibaTV/g' \
+                -e 's/Live system (amd64)/Start KibaTV/g' \
+                -e 's/Live system/Start KibaTV/g' \
+                -e 's/Graphical install/Install KibaTV to this computer/g' \
+                -e 's/Install with Speech Synthesis/Start KibaTV (screen reader)/g' \
+                -e 's/Advanced options for/More options for/g' \
+                -e 's/Live system (failsafe mode)/Start KibaTV (safe mode)/g' \
+                "$cfg"
+            done
+          else
+            echo "WARNING: No GRUB configuration found to patch"
+          fi
+
+          echo "=== GRUB boot menu branding complete ==="
+          BOOT_HOOK
+          chmod +x config/hooks/binary/0020-bootloader-branding.hook.binary
+
+          echo "=== Adding packages ==="
+
+          mkdir -p config/package-lists
+          cat > config/package-lists/kibatv.list.chroot << 'PACKAGES'
+          # ── Base system ─────────────────────────────────────────────────────
+          linux-image-amd64
+          linux-headers-amd64
+          firmware-linux-free
+          firmware-linux-nonfree
+          systemd-sysv
+          sudo
+          ca-certificates
+          openssl
+          locales
+          tzdata
+          libc6
+          libc-bin
+
+          # ── Nala (apt frontend) ─────────────────────────────────────────────
+          nala
+
+          # ── Network ─────────────────────────────────────────────────────────
+          network-manager
+          wpasupplicant
+          iwd
+          wget
+          curl
+          git
+          apt-transport-https
+
+          # ── KDE Plasma Bigscreen ───────────────────────────────────────────
+          plasma-bigscreen
+          plasma-workspace-wallpapers
+          plasma-discover
+          plasma-discover-backend-flatpak
+
+          sddm
+          sddm-theme-debian-breeze
+          plasma-nm
+          plasma-pa
+          dolphin
+          konsole
+          ark
+          qt6-svg-plugins
+          desktop-file-utils
+          plasma-wallpapers-addons
+          kwin-addons
+          breeze
+          breeze-gtk-theme
+          fonts-jetbrains-mono
+          fonts-noto-color-emoji
+          fonts-inter
+
+          # ── Flatpak ────────────────────────────────────────────────────────
+          flatpak
+          xdg-desktop-portal-kde
+          xdg-desktop-portal-gtk
+
+          # ── Shell — zsh ─────────────────────────────────────────────────────
+          zsh
+          zsh-autosuggestions
+          zsh-syntax-highlighting
+          starship
+
+          # ── Boot splash ─────────────────────────────────────────────────────
+          plymouth
+          plymouth-themes
+          kde-config-plymouth
+
+          # ── Calamares installer ─────────────────────────────────────────────
+          calamares
+          calamares-settings-debian
+          python3-pyqt6
+          python3-dbus
+
+          # ── Essential tools ─────────────────────────────────────────────────
+          nano
+          micro
+          python3
+          fastfetch
+          eza
+          bat
+          btop
+          ripgrep
+          fd-find
+          tealdeer
+          duf
+          ncdu
+          zenity
+
+          # ── Boot loaders ────────────────────────────────────────────────────
+          grub-pc-bin
+          grub-efi-amd64-bin
+          grub-common
+
+          # ── Squashfs ────────────────────────────────────────────────────────
+          squashfs-tools
+          zstd
+
+          # ── Filesystems ─────────────────────────────────────────────────────
+          ntfs-3g
+          exfatprogs
+          cryptsetup
+
+          # ── Utilities ───────────────────────────────────────────────────────
+          debianutils
+          kmod
+          binutils
+          fzf
+          yt-dlp
+          file
+          PACKAGES
+
+          echo "=== Creating live customization hook ==="
+
+          mkdir -p config/hooks/live
+          cat > config/hooks/live/0100-customize.hook.chroot << 'HOOK'
+          #!/bin/bash
+          set -e
+
+          # ── Plymouth theme — KibaTV boot splash ─────────────────────────────
+          mkdir -p /usr/share/plymouth/themes/kibatv-spinner
+          cat > /usr/share/plymouth/themes/kibatv-spinner/kibatv-spinner.plymouth << 'PLYMOUTH_THEME'
+          [Plymouth Theme]
+          Name=KibaTV
+          Description=KibaTV boot splash
+          ModuleName=script
+
+          [script]
+          ImageDir=/usr/share/plymouth/themes/kibatv-spinner
+          ScriptFile=/usr/share/plymouth/themes/kibatv-spinner/kibatv-spinner.script
+          PLYMOUTH_THEME
+
+          # (Omitted logo binary for brevity, using text-only for now or placeholder)
+          cat > /usr/share/plymouth/themes/kibatv-spinner/kibatv-spinner.script << 'PLYMOUTH_SCRIPT'
+          Window.SetBackgroundTopColor(0.157, 0.165, 0.212);
+          Window.SetBackgroundBottomColor(0.157, 0.165, 0.212);
+          screen_width  = Window.GetWidth();
+          screen_height = Window.GetHeight();
+          cx = screen_width  / 2;
+          cy = screen_height / 2;
+
+          label.image  = Image.Text("KibaTV", 0.741, 0.576, 0.976, 1, "Sans Bold 40");
+          label.sprite = Sprite(label.image);
+          label.sprite.SetPosition(cx - label.image.GetWidth() / 2, cy - 60, 1);
+
+          tag.image  = Image.Text("Switch to Simple", 0.384, 0.447, 0.643, 1, "Sans 16");
+          tag.sprite = Sprite(tag.image);
+          tag.sprite.SetPosition(cx - tag.image.GetWidth() / 2, cy + 10, 1);
+
+          bar_w = 400; bar_h = 4;
+          bar_x = cx - bar_w / 2;
+          bar_y = cy + 100;
+          bar_bg.image  = Image(bar_w, bar_h);
+          bar_bg.image.FillWithColor(0.267, 0.278, 0.349, 1.0);
+          bar_bg.sprite = Sprite(bar_bg.image);
+          bar_bg.sprite.SetPosition(bar_x, bar_y, 1);
+          bar_fg.image  = Image(1, bar_h);
+          bar_fg.image.FillWithColor(0.741, 0.576, 0.976, 1.0);
+          bar_fg.sprite = Sprite(bar_fg.image);
+          bar_fg.sprite.SetPosition(bar_x, bar_y, 2);
+          bar_fg.width  = 1;
+
+          fun progress_callback(duration, progress) {
+              new_w = Math.Int(bar_w * progress);
+              if (new_w < 1) { new_w = 1; }
+              if (new_w != bar_fg.width) {
+                  bar_fg.image  = Image(new_w, bar_h);
+                  bar_fg.image.FillWithColor(0.741, 0.576, 0.976, 1.0);
+                  bar_fg.sprite.SetImage(bar_fg.image);
+                  bar_fg.width = new_w;
+              }
+          }
+          Plymouth.SetBootProgressFunction(progress_callback);
+          PLYMOUTH_SCRIPT
+
+          update-alternatives --install \
+            /usr/share/plymouth/themes/default.plymouth default.plymouth \
+            /usr/share/plymouth/themes/kibatv-spinner/kibatv-spinner.plymouth 100
+          update-alternatives --set default.plymouth \
+            /usr/share/plymouth/themes/kibatv-spinner/kibatv-spinner.plymouth
+
+          # ── SDDM autologin for live session ─────────────────────────────────
+          mkdir -p /etc/sddm.conf.d
+          cat > /etc/sddm.conf.d/autologin.conf << 'SDDM_CONF'
+          [Autologin]
+          User=user
+          Session=plasma-bigscreen
+          SDDM_CONF
+
+          # ── Zsh config ──────────────────────────────────────────────────────
+          mkdir -p /etc/zsh
+          cat > /etc/zsh/zshrc << 'ZSHRC'
+          # KibaTV system-wide zshrc
+          export EDITOR=micro
+          eval "$(starship init zsh)"
+          alias update='sudo nala update && sudo nala upgrade -y'
+          alias ls='eza --icons --group-directories-first'
+          alias ll='eza -lah --icons --group-directories-first'
+          ZSHRC
+
+          # ── Default shell: zsh ──────────────────────────────────────────────
+          chsh -s /bin/zsh user  2>/dev/null || true
+          chsh -s /bin/zsh root  2>/dev/null || true
+
+          # ── System identity ─────────────────────────────────────────────────
+          echo "kibatv-live" > /etc/hostname
+
+          cat > /etc/os-release << 'EOF'
+          NAME="KibaTV"
+          ID=kibatv
+          ID_LIKE=debian
+          VERSION_ID="1.0"
+          PRETTY_NAME="KibaTV 1.0"
+          HOME_URL="https://github.com/WolfTech-Innovations/WolfSite"
+          EOF
+
+          HOOK
+          chmod +x config/hooks/live/0100-customize.hook.chroot
+
+          echo "=== Building ISO ==="
+          lb build 2>&1 | tee build.log
+
+          if [ -f live-image-amd64.hybrid.iso ]; then
+            mv live-image-amd64.hybrid.iso "${ISO}.iso"
+            sha256sum "${ISO}.iso" > "${ISO}.iso.sha256"
+            echo "═══ KibaTV Build Complete ═══"
+          else
+            echo "ERROR: ISO file not found!"
+            exit 1
+          fi
+          BUILD_SCRIPT_EOF
+          chmod +x build.sh
+
+      - name: Run build in Docker
+        run: |
+          docker run --rm --privileged \
+            -v "$PWD:/w" \
+            -e RUN_NUM="${{ github.run_number }}" \
+            debian:trixie \
+            /w/build.sh
+
+      - name: Upload to SourceForge
+        if: github.ref == 'refs/heads/main'
+        env:
+          SF_USER: ${{ secrets.SF_USER }}
+          SF_PASS: ${{ secrets.SF_PASS }}
+        run: |
+          if [ -z "$SF_USER" ] || [ -z "$SF_PASS" ]; then
+            echo "SourceForge credentials not configured. Skipping upload."
+            exit 0
+          fi
+          sudo apt update && sudo apt install -y sshpass rsync
+          for iso_file in *.iso; do
+            [ -f "$iso_file" ] || continue
+            sshpass -p "$SF_PASS" rsync -avP \
+              -e "ssh -o StrictHostKeyChecking=no" \
+              "$iso_file" \
+              "$SF_USER@frs.sourceforge.net:/home/frs/project/kibaos/"
+          done

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# KibaOS | Make the switch to simple
+# KibaTV | Make the switch to simple
 <img width="1330" height="519" alt="image" src="https://github.com/user-attachments/assets/1bfdb380-c332-4be1-871a-613fa0ec9887" />
 
 
-[![Download KibaOS](https://a.fsdn.com/con/app/sf-download-button)](https://sourceforge.net/projects/kibaos/files/latest/download)
+[![Download KibaTV](https://a.fsdn.com/con/app/sf-download-button)](https://sourceforge.net/projects/kibaos/files/latest/download)

--- a/index.html
+++ b/index.html
@@ -2,10 +2,10 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<meta name="description" content="WolfTech Innovations — KibaOS. Debian 13 + KDE Plasma 6. Make the switch to simple.">
+<meta name="description" content="WolfTech Innovations — KibaTV. Debian 13 + KDE Plasma Bigscreen. Make the switch to simple.">
 <meta name="author" content="WolfTech Innovations">
-<meta property="og:title" content="WolfTech Innovations — KibaOS">
-<meta property="og:description" content="KibaOS — Make the switch to simple. Debian 13 + KDE Plasma 6.">
+<meta property="og:title" content="WolfTech Innovations — KibaTV">
+<meta property="og:description" content="KibaTV — Make the switch to simple. Debian 13 + KDE Plasma Bigscreen.">
 <meta property="og:type" content="website">
 <meta name="twitter:card" content="summary">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
@@ -15,786 +15,7 @@
 <link rel="canonical" href="https://lebnix.org/">
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="laptop.css">
-<title>WolfTech Innovations — KibaOS</title>
-<style>
-  *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-  html { scroll-behavior: smooth; scroll-padding-top: 4rem; }
-  @media (prefers-reduced-motion: reduce) {
-    html { scroll-behavior: auto; }
-    .reveal { animation: none !important; opacity: 1 !important; transform: none !important; }
-  }
-
-  @keyframes fadeInUp {
-    from { opacity: 0; transform: translateY(20px); }
-    to { opacity: 1; transform: translateY(0); }
-  }
-
-  .reveal {
-    animation: fadeInUp 0.8s cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
-    opacity: 0;
-  }
-
-  .delay-1 { animation-delay: 0.1s; }
-  .delay-2 { animation-delay: 0.2s; }
-  .delay-3 { animation-delay: 0.3s; }
-
-  body {
-    font-family: 'DM Sans', sans-serif;
-    background: #f2f2f2;
-    color: #111;
-    line-height: 1.6;
-  }
-
-  a { color: #111; text-decoration: none; }
-  a:hover { text-decoration: underline; }
-  a:focus-visible { outline: 2px solid #111; outline-offset: 3px; border-radius: 4px; }
-
-  .sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border-width: 0;
-  }
-
-  .skip-link {
-    position: absolute;
-    top: -40px;
-    left: 50%;
-    transform: translateX(-50%);
-    background: #111;
-    color: #fff !important;
-    padding: 8px 16px;
-    z-index: 1000;
-    transition: top 0.2s;
-    border-radius: 0 0 10px 10px;
-  }
-  .skip-link:focus {
-    top: 0;
-  }
-
-  .w { max-width: 860px; margin: 0 auto; padding: 0 1.5rem; }
-
-  /* NAV */
-  nav {
-    position: sticky; top: 1rem; z-index: 99;
-    background: rgba(255, 255, 255, 0.8);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    border: 1px solid rgba(0,0,0,.05);
-    border-radius: 24px;
-    padding: .75rem 1.5rem;
-    display: flex; align-items: center; gap: .5rem; flex-wrap: wrap;
-    box-shadow: 0 4px 20px rgba(0,0,0,.04);
-    margin: 0 1rem;
-    max-width: calc(100% - 2rem);
-  }
-  nav a {
-    display: inline-block;
-    font-size: .875rem; font-weight: 500; color: #444;
-    padding: .35rem .7rem; border-radius: 10px;
-    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  }
-  nav a:hover { background: #f2f2f2; color: #111; text-decoration: none; }
-  nav a:active { transform: scale(0.97); }
-  .brand {
-    font-weight: 700; font-size: 1.1rem; color: #111 !important;
-    margin-right: auto;
-    letter-spacing: -0.02em;
-  }
-  .dl {
-    background: #111; color: #fff !important;
-    padding: .4rem 1.1rem !important; border-radius: 12px;
-    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  }
-  .dl:hover { background: #333 !important; }
-  .dl:active { transform: scale(0.97); }
-
-  /* HERO */
-  header {
-    padding: 5rem 0 4rem;
-    text-align: center;
-  }
-
-  .hero-card {
-    background: #fff;
-    border-radius: 32px;
-    padding: 4rem 2.5rem;
-    max-width: 720px;
-    margin: 0 auto;
-    box-shadow: 0 8px 32px rgba(0,0,0,.04);
-    border: 1px solid rgba(0,0,0,.03);
-  }
-
-  .kiba-banner {
-    width: 100%; border-radius: 16px; display: block;
-    margin-bottom: 1.75rem;
-  }
-
-  h1 {
-    font-size: clamp(2.25rem, 7vw, 4rem);
-    font-weight: 700;
-    letter-spacing: -.04em;
-    line-height: 1.05;
-    margin-bottom: .75rem;
-  }
-
-  .sub {
-    color: #555;
-    margin-bottom: 2rem;
-    font-size: 1.125rem;
-    font-weight: 400;
-    letter-spacing: -0.01em;
-  }
-
-  .tags {
-    display: flex; gap: .4rem; justify-content: center;
-    flex-wrap: wrap; margin-bottom: 2rem;
-  }
-  .tag {
-    font-size: .8rem; color: #555;
-    border: 1.5px solid #e0e0e0; border-radius: 20px;
-    padding: .25rem .8rem; background: #fff;
-    font-family: 'DM Mono', monospace;
-  }
-
-  .btns { display: flex; gap: .75rem; justify-content: center; flex-wrap: wrap; }
-  .btn {
-    display: inline-flex; align-items: center; gap: .4rem;
-    padding: .75rem 1.6rem; border-radius: 30px;
-    font-weight: 500; font-size: .9375rem;
-    text-decoration: none !important;
-    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  }
-  .btn-p { background: #111; color: #fff !important; }
-  .btn-p:hover { background: #333; }
-  .btn-s { border: 1.5px solid #ddd; color: #111 !important; background: #fff; }
-  .btn-s:hover { background: #f5f5f5; }
-  .btn:active { transform: scale(0.97); }
-
-  /* SECTIONS */
-  section { padding: 4rem 0; }
-
-  .section-card {
-    background: #fff;
-    border-radius: 28px;
-    padding: 2.5rem;
-    box-shadow: 0 4px 20px rgba(0,0,0,.03);
-    border: 1px solid rgba(0,0,0,.02);
-  }
-
-  h2 {
-    font-size: clamp(1.5rem, 4vw, 2rem);
-    font-weight: 700;
-    letter-spacing: -.03em;
-    margin-bottom: .5rem;
-  }
-
-  p.d { color: #666; margin-bottom: 1.5rem; font-size: .9375rem; }
-
-  /* GRID CARDS */
-  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: .75rem; margin-top: 1rem; }
-  .card {
-    padding: 1.5rem; border: 1px solid #f0f0f0;
-    border-radius: 20px; background: #fafafa;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-  }
-  .card:hover { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(0,0,0,.05); }
-  .card h3 { font-size: .9375rem; font-weight: 600; margin-bottom: .25rem; margin-top: .25rem; }
-  .card p { font-size: .875rem; color: #666; }
-
-  /* TABLE */
-  .tbl {
-    border: 1.5px solid #ebebeb; border-radius: 16px;
-    overflow: hidden; max-width: 480px; margin: 1rem auto 0;
-  }
-  .row {
-    display: flex; justify-content: space-between; align-items: center;
-    padding: .75rem 1.25rem; border-bottom: 1px solid #ebebeb;
-    font-size: .9375rem;
-  }
-  .row:last-child { border-bottom: none; }
-  .row:hover { background: #fafafa; }
-  .row span:last-child {
-    font-family: 'DM Mono', monospace; font-size: .8125rem;
-    color: #111; background: #f0f0f0;
-    padding: .15rem .55rem; border-radius: 8px;
-  }
-
-  /* TERMINAL */
-  .term {
-    max-width: 620px; margin: 1rem auto 0;
-    background: #1a1a1a; border-radius: 16px; overflow: hidden;
-  }
-  .tbar {
-    background: #2a2a2a; padding: .5rem 1rem;
-    display: flex; gap: .375rem; align-items: center;
-  }
-  .dot { width: 11px; height: 11px; border-radius: 50%; }
-  pre {
-    padding: 1.25rem; font-family: 'DM Mono', monospace;
-    font-size: .8125rem; line-height: 1.75;
-    color: #e8e8e8; white-space: pre-wrap;
-  }
-  .ok { color: #a8e6a3; }
-  .hi { color: #87ceeb; font-weight: 500; }
-
-  /* SPECS */
-  .specs {
-    display: grid; grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-    gap: 1px; background: #ebebeb; max-width: 560px;
-    margin: 1rem auto 0; border: 1.5px solid #ebebeb;
-    border-radius: 16px; overflow: hidden;
-  }
-  .spec { background: #fff; padding: 1.125rem; text-align: center; }
-  .spec small {
-    display: block; font-size: .6875rem; color: #666;
-    text-transform: uppercase; letter-spacing: .07em; margin-bottom: .25rem;
-  }
-  .spec strong { font-size: .9375rem; font-weight: 600; }
-
-  /* STEPS */
-  .steps {
-    display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    gap: 1.25rem; max-width: 540px; margin: 1rem auto 0; text-align: center;
-  }
-  .step em {
-    display: inline-flex; width: 2rem; height: 2rem;
-    background: #111; color: #fff; border-radius: 50%;
-    align-items: center; justify-content: center;
-    font-style: normal; font-weight: 700; margin-bottom: .5rem;
-    font-family: 'DM Mono', monospace; font-size: .875rem;
-  }
-  .step h3 { font-size: .9375rem; font-weight: 600; margin-bottom: .2rem; }
-  .step p { font-size: .8125rem; color: #666; }
-
-  /* REQUIREMENTS TABLE */
-  .req-tbl { border: 1.5px solid #ebebeb; border-radius: 16px; overflow: hidden; margin-top: 1rem; }
-  .req-row {
-    display: flex; justify-content: space-between;
-    padding: .7rem 1.25rem; border-bottom: 1px solid #ebebeb;
-    font-size: .9rem;
-  }
-  .req-row:last-child { border-bottom: none; }
-  .req-row:hover { background: #fafafa; }
-  .req-row .label { color: #666; font-size: .85rem; }
-  .req-row .val { font-family: 'DM Mono', monospace; font-size: .82rem; background: #f0f0f0; padding: .15rem .55rem; border-radius: 8px; }
-
-  /* TEAM */
-  .team { max-width: 560px; margin: 0 auto; display: grid; gap: .75rem; }
-  .member {
-    display: flex; gap: 1rem; padding: 1rem 1.25rem;
-    border: 1.5px solid #ebebeb; border-radius: 16px;
-    align-items: center; background: #fafafa;
-  }
-  .member img, .av {
-    width: 44px; height: 44px; border-radius: 50%;
-    flex-shrink: 0; object-fit: cover;
-  }
-  .av {
-    background: #e8e8e8; display: flex; align-items: center;
-    justify-content: center; font-weight: 700; color: #666; font-size: .875rem;
-  }
-  .member small { display: block; font-size: .6875rem; color: #666; font-weight: 600; text-transform: uppercase; letter-spacing: .05em; }
-  .member strong { display: block; font-size: .9375rem; font-weight: 600; }
-
-  /* THEME TABLE */
-  .theme-grid {
-    display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-    gap: .6rem; margin-top: 1rem;
-  }
-  .theme-swatch {
-    border-radius: 12px; overflow: hidden;
-    border: 1.5px solid #ebebeb;
-  }
-  .swatch-color { height: 36px; }
-  .swatch-info { background: #fff; padding: .45rem .65rem; }
-  .swatch-info small { display: block; font-size: .7rem; color: #666; }
-  .swatch-info span { font-family: 'DM Mono', monospace; font-size: .75rem; font-weight: 500; }
-
-  /* SPONSOR */
-  .scard {
-    max-width: 640px; margin: 0 auto;
-    border: 1.5px solid #ebebeb; border-radius: 20px; overflow: hidden;
-  }
-  .shd {
-    background: #111; padding: 2rem; color: #fff;
-  }
-  .shd h3 { font-size: 1.15rem; font-weight: 700; margin-bottom: .375rem; }
-  .shd p { opacity: .75; font-size: .9375rem; max-width: 420px; }
-  .sbody { padding: 1.5rem; }
-  .srow {
-    display: flex; align-items: center; gap: 1rem; padding: 1rem;
-    background: #fafafa; border: 1.5px solid #ebebeb;
-    border-radius: 14px; margin-bottom: 1.25rem; flex-wrap: wrap;
-  }
-  .srow strong { font-size: .9375rem; display: block; }
-  .srow small { color: #666; font-size: .8125rem; }
-  .badge-g {
-    margin-left: auto; background: #e8f5e9; color: #2e7d32;
-    font-size: .75rem; font-weight: 600; padding: .2rem .7rem;
-    border-radius: 20px;
-  }
-  .sbtn {
-    display: flex; align-items: center; justify-content: center;
-    gap: .5rem; width: 100%; padding: .75rem;
-    background: #111; color: #fff !important;
-    border-radius: 12px; font-weight: 500;
-    text-decoration: none !important;
-  }
-  .sbtn:hover { background: #333; }
-  .sft {
-    padding: .75rem 1.5rem; background: #fafafa;
-    border-top: 1px solid #ebebeb; font-size: .8125rem; color: #666;
-  }
-
-  /* FOOTER */
-  footer {
-    padding: 2rem 0; text-align: center; margin-top: 1rem;
-  }
-  footer nav {
-    display: flex; gap: 1.5rem; justify-content: center;
-    flex-wrap: wrap; margin-bottom: .75rem;
-    border: none; position: static; padding: 0;
-    background: none; box-shadow: none; border-radius: 0;
-  }
-  footer nav a { font-size: .875rem; color: #666; display: inline-block; transition: transform 0.2s; }
-  footer nav a:hover { color: #111; }
-  footer nav a:active { transform: scale(0.97); }
-  footer p { font-size: .8125rem; color: #666; }
-
-  /* CREDENTIALS TABLE */
-  .cred-tbl { border: 1.5px solid #ebebeb; border-radius: 14px; overflow: hidden; max-width: 340px; margin: 1rem 0 0; }
-  .cred-row { display: flex; justify-content: space-between; padding: .65rem 1.1rem; border-bottom: 1px solid #ebebeb; font-size: .9rem; }
-  .cred-row:last-child { border-bottom: none; }
-  .cred-row span:last-child { font-family: 'DM Mono', monospace; font-size: .82rem; background: #f0f0f0; padding: .12rem .5rem; border-radius: 8px; }
-
-  /* CODE BLOCK */
-  .code-block {
-    background: #1a1a1a; border-radius: 14px; padding: 1.1rem 1.25rem;
-    font-family: 'DM Mono', monospace; font-size: .8rem;
-    color: #e8e8e8; margin-top: .75rem; line-height: 1.7;
-    overflow-x: auto; white-space: pre;
-  }
-
-  /* LAPTOP (inlined from laptop.css) */
-  .laptop-container {
-    perspective: 1500px;
-    width: 100%;
-    max-width: 600px;
-    margin: 0 auto 2rem;
-    display: flex;
-    justify-content: center;
-    align-items: flex-end;
-    height: 380px;
-    position: relative;
-  }
-  .laptop {
-    position: relative;
-    width: 100%;
-    height: 100%;
-    transform-style: preserve-3d;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-end;
-    align-items: center;
-  }
-  .laptop-lid {
-    width: 86%;
-    height: 84%;
-    background: #2a2a2a;
-    border-radius: 10px 10px 0 0;
-    position: relative;
-    transform-origin: bottom center;
-    transform: rotateX(-100deg);
-    animation: openLid 1.6s cubic-bezier(0.4, 0, 0.2, 1) forwards;
-    animation-delay: 0.4s;
-    z-index: 2;
-    border: 2px solid #444;
-    border-bottom: none;
-    overflow: hidden;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    box-shadow: inset 0 0 20px rgba(0,0,0,0.5);
-  }
-  .laptop-lid::before {
-    content: '';
-    position: absolute;
-    top: 7px;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 5px;
-    height: 5px;
-    background: #555;
-    border-radius: 50%;
-    z-index: 3;
-  }
-  .laptop-screen {
-    width: 92%;
-    height: 90%;
-    background: #000;
-    border-radius: 2px;
-    overflow: hidden;
-    position: relative;
-    margin-top: -4px;
-  }
-  .laptop-screen img {
-    width: 100%;
-    height: 100%;
-    object-fit: fill;
-    display: block;
-    opacity: 0;
-    animation: fadeInScreen 0.8s ease-in forwards;
-    animation-delay: 1.8s;
-  }
-  .laptop-base {
-    width: 96%;
-    height: 16px;
-    background: #2a2a2a;
-    border-radius: 0 0 10px 10px;
-    position: relative;
-    z-index: 3;
-    box-shadow: 0 8px 24px rgba(0,0,0,0.3);
-  }
-  .laptop-base::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 22%;
-    height: 6px;
-    background: #1e1e1e;
-    border-radius: 0 0 6px 6px;
-  }
-  .laptop-base::after {
-    content: '';
-    position: absolute;
-    bottom: -1px;
-    left: 5%;
-    right: 5%;
-    height: 3px;
-    background: #1a1a1a;
-    border-radius: 0 0 10px 10px;
-  }
-  @keyframes openLid {
-    0%   { transform: rotateX(-100deg); }
-    100% { transform: rotateX(-5deg); }
-  }
-  @keyframes fadeInScreen {
-    to { opacity: 1; }
-  }
-  @media (max-width: 600px) {
-    .laptop-container { height: 260px; }
-  }
-  @media (max-width: 400px) {
-    .laptop-container { height: 200px; }
-  }
-  @media (prefers-reduced-motion: reduce) {
-    .laptop-lid { transform: rotateX(-5deg); animation: none; }
-    .laptop-screen img { opacity: 1; animation: none; }
-  }
-</style>
-</head>
-<body>
-
-<a href="#main" class="skip-link">Skip to main content</a>
-
-<nav aria-label="Site navigation">
-  <a href="#" class="brand">WolfTech Innovations</a>
-  <a href="#about">About</a>
-  <a href="#sponsor">Sponsor</a>
-  <a href="#team">Team</a>
-  <a href="https://nox.lebnix.org" target="_blank" rel="noopener">Nox</a>
-  <a href="https://sourceforge.net/projects/kibaos/files/latest/download" class="dl" aria-label="Download KibaOS ISO from SourceForge"><span aria-hidden="true">⬇</span> Download</a>
-</nav>
-
-<main id="main">
-
-<header>
-<img 
-  src="https://raw.githubusercontent.com/WolfTech-Innovations/WolfSite/main/img-etc/Screenshot_20260429_203727-front.png"
-  alt="KibaOS Desktop"
-  class="kiba-banner"
-  style="width:100%;max-width:600px;border-radius:0;display:block;margin:0 auto -8% auto;"
->
-      <h1>KibaOS</h1>
-      <p class="sub">Make the switch to simple — by WolfTech Innovations</p>
-      <div class="tags">
-        <span class="tag">Debian 13 Trixie</span>
-        <span class="tag">KDE Plasma 6</span>
-        <span class="tag">Dracula Theme</span>
-        <span class="tag">Wayland</span>
-        <span class="tag">Live ISO</span>
-      </div>
-      <div class="btns">
-        <a href="https://sourceforge.net/projects/kibaos/files/latest/download" class="btn btn-p" aria-label="Download KibaOS ISO from SourceForge"><span aria-hidden="true">⬇</span> Download ISO</a>
-        <a href="https://github.com/WolfTech-Innovations/Kiba" target="_blank" rel="noopener" class="btn btn-s">GitHub</a>
-        <a href="https://nox.lebnix.org" target="_blank" rel="noopener" class="btn btn-s"><span aria-hidden="true">🛒</span> Nox Marketplace</a>
-      </div>
-    </div>
-  </div>
-</header>
-
-<section id="about">
-  <div class="w">
-    <div class="section-card reveal">
-      <h2>About KibaOS</h2>
-      <p class="d">A clean, modern Linux distribution built on Debian 13 (Trixie) with KDE Plasma 6. Everything is pre-configured and ready to use — no post-install tweaking required.</p>
-      <div class="grid">
-        <div class="card"><span aria-hidden="true">✨</span> <h3>Pre-configured</h3><p>Dracula theme, Zsh, and a floating taskbar — all set up out of the box.</p></div>
-        <div class="card"><span aria-hidden="true">🖥️</span> <h3>KDE Plasma 6</h3><p>Wayland by default with rounded corners and a modern compositor.</p></div>
-        <div class="card"><span aria-hidden="true">✅</span> <h3>Stable Base</h3><p>Built on Debian 13 Trixie, supported until 2030.</p></div>
-        <div class="card"><span aria-hidden="true">🚫</span> <h3>No Bloat</h3><p>Only what you need is installed — nothing more.</p></div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section>
-  <div class="w">
-    <div class="section-card">
-      <h2>What's Included</h2>
-      <div class="grid">
-        <div class="card"><h3>KDE Plasma 6.3</h3><p>Floating rounded taskbar, 12px rounded corners, Wayland default.</p></div>
-        <div class="card"><h3>Dracula Theme</h3><p>Applied system-wide — widgets, terminal, decorations, Plymouth.</p></div>
-        <div class="card"><h3>Zsh Shell</h3><p>Autosuggestions, syntax highlighting, and useful aliases pre-configured.</p></div>
-        <div class="card"><h3>Essential Apps</h3><p>Firefox ESR, Dolphin, Konsole, Kate, VLC, GParted.</p></div>
-        <div class="card"><h3>Calamares Installer</h3><p>Graphical installer with KibaOS branding.</p></div>
-        <div class="card"><h3>Live Session</h3><p>Boots into KDE with auto-login. Try before you install.</p></div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section>
-  <div class="w">
-    <div class="section-card">
-      <h2>Components</h2>
-      <div class="tbl" role="table" aria-label="Software components">
-        <div class="row" role="row"><span>Desktop</span><span>KDE Plasma 6.3</span></div>
-        <div class="row" role="row"><span>Session</span><span>Wayland</span></div>
-        <div class="row" role="row"><span>Shell</span><span>Zsh</span></div>
-        <div class="row" role="row"><span>Display Manager</span><span>SDDM</span></div>
-        <div class="row" role="row"><span>Terminal</span><span>Konsole</span></div>
-        <div class="row" role="row"><span>File Manager</span><span>Dolphin</span></div>
-        <div class="row" role="row"><span>Browser</span><span>Firefox ESR</span></div>
-        <div class="row" role="row"><span>Installer</span><span>Calamares</span></div>
-        <div class="row" role="row"><span>Boot Splash</span><span>Plymouth</span></div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section>
-  <div class="w">
-    <div class="section-card">
-      <h2>System Requirements</h2>
-      <div class="req-tbl">
-        <div class="req-row"><span class="label">CPU</span><span class="val">64-bit x86 (amd64)</span></div>
-        <div class="req-row"><span class="label">RAM</span><span class="val">2 GB (4 GB recommended)</span></div>
-        <div class="req-row"><span class="label">Disk</span><span class="val">20 GB for installation</span></div>
-        <div class="req-row"><span class="label">GPU</span><span class="val">OpenGL 2.0+</span></div>
-        <div class="req-row"><span class="label">Firmware</span><span class="val">UEFI or legacy BIOS</span></div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section>
-  <div class="w">
-    <div class="section-card">
-      <h2>Specifications</h2>
-      <div class="specs" role="table" aria-label="Specifications">
-        <div class="spec"><small>Base</small><strong>Debian 13</strong></div>
-        <div class="spec"><small>Desktop</small><strong>KDE Plasma 6</strong></div>
-        <div class="spec"><small>Session</small><strong>Wayland</strong></div>
-        <div class="spec"><small>DM</small><strong>SDDM</strong></div>
-        <div class="spec"><small>Type</small><strong>Live ISO</strong></div>
-        <div class="spec"><small>RAM</small><strong>2 GB min</strong></div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section>
-  <div class="w">
-    <div class="section-card">
-      <h2>Dracula Theme</h2>
-      <p class="d">KibaOS ships the full Dracula palette system-wide — every surface, widget, and terminal window is consistent.</p>
-      <div class="theme-grid">
-        <div class="theme-swatch"><div class="swatch-color" style="background:#282a36"></div><div class="swatch-info"><small>Background</small><span>#282a36</span></div></div>
-        <div class="theme-swatch"><div class="swatch-color" style="background:#44475a"></div><div class="swatch-info"><small>Current Line</small><span>#44475a</span></div></div>
-        <div class="theme-swatch"><div class="swatch-color" style="background:#bd93f9"></div><div class="swatch-info"><small>Purple</small><span>#bd93f9</span></div></div>
-        <div class="theme-swatch"><div class="swatch-color" style="background:#ff79c6"></div><div class="swatch-info"><small>Pink</small><span>#ff79c6</span></div></div>
-        <div class="theme-swatch"><div class="swatch-color" style="background:#8be9fd"></div><div class="swatch-info"><small>Cyan</small><span>#8be9fd</span></div></div>
-        <div class="theme-swatch"><div class="swatch-color" style="background:#50fa7b"></div><div class="swatch-info"><small>Green</small><span>#50fa7b</span></div></div>
-        <div class="theme-swatch"><div class="swatch-color" style="background:#f1fa8c"></div><div class="swatch-info"><small>Yellow</small><span>#f1fa8c</span></div></div>
-        <div class="theme-swatch"><div class="swatch-color" style="background:#ff5555"></div><div class="swatch-info"><small>Red</small><span>#ff5555</span></div></div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section>
-  <div class="w">
-    <div class="section-card">
-      <h2>Boot Sequence</h2>
-      <div class="term" role="region" aria-label="Boot log">
-        <div class="tbar" aria-hidden="true">
-          <div class="dot" style="background:#ea4335"></div>
-          <div class="dot" style="background:#fbbc04"></div>
-          <div class="dot" style="background:#34a853"></div>
-        </div>
-        <pre>Starting KibaOS Live System...
-
-<span class="ok">[ OK ] Mount filesystems
-[ OK ] Load KDE modules
-[ OK ] Start SDDM display manager
-[ OK ] Apply Dracula theme</span>
-
-<span class="hi">Booting into KDE Plasma 6 (Wayland)...</span>
-
-Starting Plymouth boot splash...
-Loading Zsh with pre-configured aliases...
-Auto-login as user (live session)...
-
-<span class="hi">Welcome to KibaOS — WolfTech Innovations</span></pre>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section>
-  <div class="w">
-    <div class="section-card">
-      <h2>Live Session Credentials</h2>
-      <p class="d">Default accounts for the live environment only. The installer will prompt you to set your own.</p>
-      <div class="cred-tbl">
-        <div class="cred-row"><span>user</span><span>live</span></div>
-        <div class="cred-row"><span>root</span><span>root</span></div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section>
-  <div class="w">
-    <div class="section-card">
-      <h2>Writing to USB</h2>
-      <p class="d">Use Balena Etcher, Ventoy, or <code style="background:#f0f0f0;padding:.1rem .4rem;border-radius:6px;font-family:'DM Mono',monospace;font-size:.85em">dd</code> on Linux.</p>
-      <div class="code-block">sudo dd if=kibaos-vN.iso of=/dev/sdX bs=4M status=progress oflag=sync</div>
-      <p style="font-size:.85rem;color:#666;margin-top:.6rem">Replace <code style="background:#f0f0f0;padding:.1rem .3rem;border-radius:5px;font-family:'DM Mono',monospace">/dev/sdX</code> with your drive and <code style="background:#f0f0f0;padding:.1rem .3rem;border-radius:5px;font-family:'DM Mono',monospace">N</code> with the build number.</p>
-    </div>
-  </div>
-</section>
-
-<section>
-  <div class="w">
-    <div class="section-card" style="text-align:center">
-      <h2>Get Started</h2>
-      <div class="steps">
-        <div class="step"><em>1</em><h3>Download</h3><p>Get the ISO from SourceForge</p></div>
-        <div class="step"><em>2</em><h3>Flash</h3><p>Write to USB with Etcher</p></div>
-        <div class="step"><em>3</em><h3>Boot</h3><p>Try the live session</p></div>
-        <div class="step"><em>4</em><h3>Install</h3><p>Run Calamares installer</p></div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section id="sponsor">
-  <div class="w reveal">
-    <h2 style="margin-bottom:.5rem">Support WolfTech Innovations</h2>
-    <p class="d">Help fund active hardware and software development — including our ARM-based digital signage SBC.</p>
-    <div class="scard">
-      <div class="shd">
-        <h3>Fund the WolfTech Digital Signage Device</h3>
-        <p>An ARM-based SBC purpose-built for digital menu and display signage — designed and built by WolfTech Innovations.</p>
-      </div>
-      <div class="sbody">
-        <div class="srow">
-          <span style="font-size:1.5rem" aria-hidden="true">🖥️</span>
-          <div><strong>WolfTech SBC — Digital Signage</strong><small>ARM · Custom PCB · 2-layer</small></div>
-          <span class="badge-g">In Development</span>
-        </div>
-        <a href="https://github.com/sponsors/WolfTech-Innovations" target="_blank" rel="noopener" class="sbtn"><span aria-hidden="true">♥</span> Sponsor on GitHub</a>
-        <img src="https://raw.githubusercontent.com/WolfTech-Innovations/WolfSite/c2df07526725b63d911d8ba556f3b07e0ec16c1f/img-etc/render.png" alt="WolfTech digital signage SBC render" loading="lazy" style="width:100%;border-radius:12px;margin-top:1.25rem;display:block">
-      </div>
-      <div class="sft">🔒 Payments via GitHub Sponsors · MIT Licensed</div>
-    </div>
-  </div>
-</section>
-
-<section id="team">
-  <div class="w reveal">
-    <h2 style="margin-bottom:1rem">Team</h2>
-    <div class="team">
-      <div class="member">
-        <img src="https://github.com/WolfTech-Innovations/cybr/blob/master/images/a61461eb5aa17bc11e57c985cb68e248.png?raw=true" alt="Christopher L Fox Jr." loading="lazy">
-        <div>
-          <small>CEO &amp; Lead Developer</small>
-          <strong>Christopher L Fox Jr.</strong>
-        </div>
-      </div>
-      <div class="member">
-        <div class="av">JD</div>
-        <div>
-          <small>HR &amp; Marketing</small>
-          <strong>Joseph Daniels Stratton</strong>
-        </div>
-      </div>
-      <div class="member">
-        <img src="https://raw.githubusercontent.com/WolfTech-Innovations/cybr/refs/heads/master/images/Snapchat-969259657.jpg" alt="Christopher Ray Fricks" loading="lazy">
-        <div>
-          <small>Programming, Finance &amp; Testing</small>
-          <strong>Christopher Ray Fricks</strong>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-</main>
-
-<footer>
-  <div class="w">
-    <nav aria-label="Footer links">
-      <a href="https://github.com/WolfTech-Innovations/Kiba" target="_blank" rel="noopener">GitHub</a>
-      <a href="https://nox.lebnix.org" target="_blank" rel="noopener">Nox Marketplace</a>
-      <a href="https://kde.org/plasma-desktop/" target="_blank" rel="noopener">KDE Plasma</a>
-      <a href="https://sourceforge.net/projects/kibaos/" target="_blank" rel="noopener">SourceForge</a>
-      <a href="https://github.com/WolfTech-Innovations/Kiba/issues" target="_blank" rel="noopener">Issues</a>
-      <a href="https://github.com/sponsors/WolfTech-Innovations" target="_blank" rel="noopener">Sponsor</a>
-    </nav>
-    <p>&copy; 2026 WolfTech Innovations — MIT Licensed</p>
-  </div>
-</footer>
-
-</body>
-</html><!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<meta name="description" content="WolfTech Innovations — KibaOS. Debian 13 + KDE Plasma 6. Make the switch to simple.">
-<meta name="author" content="WolfTech Innovations">
-<meta property="og:title" content="WolfTech Innovations — KibaOS">
-<meta property="og:description" content="KibaOS — Make the switch to simple. Debian 13 + KDE Plasma 6.">
-<meta property="og:type" content="website">
-<meta name="twitter:card" content="summary">
-<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-<link rel="manifest" href="/site.webmanifest">
-<link rel="canonical" href="https://lebnix.org/">
-<link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="laptop.css">
-<title>WolfTech Innovations — KibaOS</title>
+<title>WolfTech Innovations — KibaTV</title>
 <style>
   *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
   html { scroll-behavior: smooth; scroll-padding-top: 4rem; }
@@ -1279,7 +500,7 @@ Auto-login as user (live session)...
   <a href="#sponsor">Sponsor</a>
   <a href="#team">Team</a>
   <a href="https://nox.lebnix.org" target="_blank" rel="noopener">Nox</a>
-  <a href="https://sourceforge.net/projects/kibaos/files/latest/download" class="dl" aria-label="Download KibaOS ISO from SourceForge"><span aria-hidden="true">⬇</span> Download</a>
+  <a href="https://sourceforge.net/projects/kibaos/files/latest/download" class="dl" aria-label="Download KibaTV ISO from SourceForge"><span aria-hidden="true">⬇</span> Download</a>
 </nav>
 
 <main id="main">
@@ -1291,23 +512,23 @@ Auto-login as user (live session)...
         <div class="laptop">
           <div class="laptop-lid">
             <div class="laptop-screen">
-              <img src="/img-etc/Screenshot_20260429_203727.png" alt="KibaOS Desktop">
+              <img src="/img-etc/Screenshot_20260429_203727.png" alt="KibaTV Desktop">
             </div>
           </div>
           <div class="laptop-base"></div>
         </div>
       </div>
-      <h1>KibaOS</h1>
+      <h1>KibaTV</h1>
       <p class="sub">Make the switch to simple — by WolfTech Innovations</p>
       <div class="tags">
         <span class="tag">Debian 13 Trixie</span>
-        <span class="tag">KDE Plasma 6</span>
+        <span class="tag">KDE Plasma Bigscreen</span>
         <span class="tag">Dracula Theme</span>
         <span class="tag">Wayland</span>
         <span class="tag">Live ISO</span>
       </div>
       <div class="btns">
-        <a href="https://sourceforge.net/projects/kibaos/files/latest/download" class="btn btn-p" aria-label="Download KibaOS ISO from SourceForge"><span aria-hidden="true">⬇</span> Download ISO</a>
+        <a href="https://sourceforge.net/projects/kibaos/files/latest/download" class="btn btn-p" aria-label="Download KibaTV ISO from SourceForge"><span aria-hidden="true">⬇</span> Download ISO</a>
         <a href="https://github.com/WolfTech-Innovations/Kiba" target="_blank" rel="noopener" class="btn btn-s">GitHub</a>
         <a href="https://nox.lebnix.org" target="_blank" rel="noopener" class="btn btn-s"><span aria-hidden="true">🛒</span> Nox Marketplace</a>
       </div>
@@ -1318,11 +539,11 @@ Auto-login as user (live session)...
 <section id="about">
   <div class="w">
     <div class="section-card reveal">
-      <h2>About KibaOS</h2>
-      <p class="d">A clean, modern Linux distribution built on Debian 13 (Trixie) with KDE Plasma 6. Everything is pre-configured and ready to use — no post-install tweaking required.</p>
+      <h2>About KibaTV</h2>
+      <p class="d">A clean, modern Linux distribution built on Debian 13 (Trixie) with KDE Plasma Bigscreen. Everything is pre-configured and ready to use — no post-install tweaking required.</p>
       <div class="grid">
         <div class="card"><span aria-hidden="true">✨</span> <h3>Pre-configured</h3><p>Dracula theme, Zsh, and a floating taskbar — all set up out of the box.</p></div>
-        <div class="card"><span aria-hidden="true">🖥️</span> <h3>KDE Plasma 6</h3><p>Wayland by default with rounded corners and a modern compositor.</p></div>
+        <div class="card"><span aria-hidden="true">🖥️</span> <h3>KDE Plasma Bigscreen</h3><p>Wayland by default with rounded corners and a modern compositor.</p></div>
         <div class="card"><span aria-hidden="true">✅</span> <h3>Stable Base</h3><p>Built on Debian 13 Trixie, supported until 2030.</p></div>
         <div class="card"><span aria-hidden="true">🚫</span> <h3>No Bloat</h3><p>Only what you need is installed — nothing more.</p></div>
       </div>
@@ -1335,11 +556,11 @@ Auto-login as user (live session)...
     <div class="section-card">
       <h2>What's Included</h2>
       <div class="grid">
-        <div class="card"><h3>KDE Plasma 6.3</h3><p>Floating rounded taskbar, 12px rounded corners, Wayland default.</p></div>
+        <div class="card"><h3>KDE Plasma Bigscreen</h3><p>Floating rounded taskbar, 12px rounded corners, Wayland default.</p></div>
         <div class="card"><h3>Dracula Theme</h3><p>Applied system-wide — widgets, terminal, decorations, Plymouth.</p></div>
         <div class="card"><h3>Zsh Shell</h3><p>Autosuggestions, syntax highlighting, and useful aliases pre-configured.</p></div>
         <div class="card"><h3>Essential Apps</h3><p>Firefox ESR, Dolphin, Konsole, Kate, VLC, GParted.</p></div>
-        <div class="card"><h3>Calamares Installer</h3><p>Graphical installer with KibaOS branding.</p></div>
+        <div class="card"><h3>Calamares Installer</h3><p>Graphical installer with KibaTV branding.</p></div>
         <div class="card"><h3>Live Session</h3><p>Boots into KDE with auto-login. Try before you install.</p></div>
       </div>
     </div>
@@ -1351,7 +572,7 @@ Auto-login as user (live session)...
     <div class="section-card">
       <h2>Components</h2>
       <div class="tbl" role="table" aria-label="Software components">
-        <div class="row" role="row"><span>Desktop</span><span>KDE Plasma 6.3</span></div>
+        <div class="row" role="row"><span>Desktop</span><span>KDE Plasma Bigscreen</span></div>
         <div class="row" role="row"><span>Session</span><span>Wayland</span></div>
         <div class="row" role="row"><span>Shell</span><span>Zsh</span></div>
         <div class="row" role="row"><span>Display Manager</span><span>SDDM</span></div>
@@ -1386,7 +607,7 @@ Auto-login as user (live session)...
       <h2>Specifications</h2>
       <div class="specs" role="table" aria-label="Specifications">
         <div class="spec"><small>Base</small><strong>Debian 13</strong></div>
-        <div class="spec"><small>Desktop</small><strong>KDE Plasma 6</strong></div>
+        <div class="spec"><small>Desktop</small><strong>KDE Plasma Bigscreen</strong></div>
         <div class="spec"><small>Session</small><strong>Wayland</strong></div>
         <div class="spec"><small>DM</small><strong>SDDM</strong></div>
         <div class="spec"><small>Type</small><strong>Live ISO</strong></div>
@@ -1400,7 +621,7 @@ Auto-login as user (live session)...
   <div class="w">
     <div class="section-card">
       <h2>Dracula Theme</h2>
-      <p class="d">KibaOS ships the full Dracula palette system-wide — every surface, widget, and terminal window is consistent.</p>
+      <p class="d">KibaTV ships the full Dracula palette system-wide — every surface, widget, and terminal window is consistent.</p>
       <div class="theme-grid">
         <div class="theme-swatch"><div class="swatch-color" style="background:#282a36"></div><div class="swatch-info"><small>Background</small><span>#282a36</span></div></div>
         <div class="theme-swatch"><div class="swatch-color" style="background:#44475a"></div><div class="swatch-info"><small>Current Line</small><span>#44475a</span></div></div>
@@ -1425,20 +646,20 @@ Auto-login as user (live session)...
           <div class="dot" style="background:#fbbc04"></div>
           <div class="dot" style="background:#34a853"></div>
         </div>
-        <pre>Starting KibaOS Live System...
+        <pre>Starting KibaTV Live System...
 
 <span class="ok">[ OK ] Mount filesystems
 [ OK ] Load KDE modules
 [ OK ] Start SDDM display manager
 [ OK ] Apply Dracula theme</span>
 
-<span class="hi">Booting into KDE Plasma 6 (Wayland)...</span>
+<span class="hi">Booting into KDE Plasma Bigscreen (Wayland)...</span>
 
 Starting Plymouth boot splash...
 Loading Zsh with pre-configured aliases...
 Auto-login as user (live session)...
 
-<span class="hi">Welcome to KibaOS — WolfTech Innovations</span></pre>
+<span class="hi">Welcome to KibaTV — WolfTech Innovations</span></pre>
       </div>
     </div>
   </div>
@@ -1462,7 +683,7 @@ Auto-login as user (live session)...
     <div class="section-card">
       <h2>Writing to USB</h2>
       <p class="d">Use Balena Etcher, Ventoy, or <code style="background:#f0f0f0;padding:.1rem .4rem;border-radius:6px;font-family:'DM Mono',monospace;font-size:.85em">dd</code> on Linux.</p>
-      <div class="code-block">sudo dd if=kibaos-vN.iso of=/dev/sdX bs=4M status=progress oflag=sync</div>
+      <div class="code-block">sudo dd if=kibatv-vN.iso of=/dev/sdX bs=4M status=progress oflag=sync</div>
       <p style="font-size:.85rem;color:#666;margin-top:.6rem">Replace <code style="background:#f0f0f0;padding:.1rem .3rem;border-radius:5px;font-family:'DM Mono',monospace">/dev/sdX</code> with your drive and <code style="background:#f0f0f0;padding:.1rem .3rem;border-radius:5px;font-family:'DM Mono',monospace">N</code> with the build number.</p>
     </div>
   </div>
@@ -1541,7 +762,7 @@ Auto-login as user (live session)...
     <nav aria-label="Footer links">
       <a href="https://github.com/WolfTech-Innovations/Kiba" target="_blank" rel="noopener">GitHub</a>
       <a href="https://nox.lebnix.org" target="_blank" rel="noopener">Nox Marketplace</a>
-      <a href="https://kde.org/plasma-desktop/" target="_blank" rel="noopener">KDE Plasma</a>
+      <a href="https://kde.org/plasma-desktop/" target="_blank" rel="noopener">KDE Plasma Bigscreen</a>
       <a href="https://sourceforge.net/projects/kibaos/" target="_blank" rel="noopener">SourceForge</a>
       <a href="https://github.com/WolfTech-Innovations/Kiba/issues" target="_blank" rel="noopener">Issues</a>
       <a href="https://github.com/sponsors/WolfTech-Innovations" target="_blank" rel="noopener">Sponsor</a>

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,1 +1,1 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{"name":"KibaTV","short_name":"KibaTV","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}


### PR DESCRIPTION
This pull request rebrands the project from "KibaOS" to "KibaTV" and transitions the desktop environment to KDE Plasma Bigscreen. Key changes include a global text update across the website and README, the removal of the external `build.sh` in favor of an integrated GitHub Actions workflow configured for `plasma-bigscreen`, and the resolution of a code duplication issue in `index.html`. All existing themes (Dracula) and the Debian 13 base are maintained.

---
*PR created automatically by Jules for task [11250420880883793501](https://jules.google.com/task/11250420880883793501) started by @christopherfoxjr*