### PR TITLE
🎨 Palette: Improve color contrast for .badge-immutable

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,7 +256,7 @@
 
   /* IMMUTABLE BADGE */
   .badge-immutable {
-    display: inline-block; background: #fff3e0; color: #e65100;
+    display: inline-block; background: #fff3e0; color: #bf360c;
     font-size: .75rem; font-weight: 600; padding: .2rem .7rem;
     border-radius: 20px; font-family: 'DM Mono', monospace;
     border: 1px solid #ffe0b2; margin-left: .5rem;


### PR DESCRIPTION
💡 What: Improved the color contrast for the `.badge-immutable` component in `index.html`.
🎯 Why: The previous text color (`#e65100`) on the light orange background (`#fff3e0`) had a contrast ratio of ~4.0:1, which is below the WCAG AA requirement of 4.5:1 for small text. The new color (`#bf360c`) achieves a ratio of ~5.4:1.
♿ Accessibility: Directly improves readability for users with visual impairments by satisfying WCAG AA standards.
📸 Verification: Visual confirmation performed via Playwright screenshots.

---
*PR created automatically by Jules for task [2176719766009063836](https://jules.google.com/task/2176719766009063836) started by @christopherfoxjr*