### PR TITLE
🎨 Palette: Fix sticky header overlap with scroll-padding-top

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
 }
 
 *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
-html { scroll-behavior: smooth; }
+html { scroll-behavior: smooth; scroll-padding-top: 64px; }
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }
   * { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; }


### PR DESCRIPTION
This PR addresses a common micro-UX issue where the 64px sticky navigation bar overlaps the top of sections when navigating via internal anchor links (e.g., clicking 'Features' or 'About').

💡 **What**: Added `scroll-padding-top: 64px;` to the global `html` selector.
🎯 **Why**: To ensure that section titles are clearly visible below the header after an anchor navigation, improving the clarity and flow of the user journey.
♿ **Accessibility**: Improves keyboard and screen reader navigation by ensuring the visual focus and destination content are not hidden behind UI chrome.

Verified with Playwright: The `#features` section now scrolls to exactly 63.6px from the top (accounting for sub-pixel rendering), perfectly clearing the 64px header.

---
*PR created automatically by Jules for task [699991245421992182](https://jules.google.com/task/699991245421992182) started by @christopherfoxjr*