### PR TITLE
🎨 Palette: Improve contrast for secondary labels

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2026-05-02 - [Accessible Branding for Skip Links]
 **Learning:** Skip links are critical for keyboard navigation but are often styled as afterthoughts. Using a brand accent color (like Dracula Purple #bd93f9) with bold, high-contrast text (#111) makes the link feel like an intentional part of the UI rather than a "hidden" utility. A prominent internal focus outline (`outline-offset: -3px`) ensures visibility even on complex headers.
 **Action:** Always theme skip links with high-contrast brand colors and use inset outlines to ensure visibility against varied header backgrounds.
+
+## 2026-06-05 - [Targeted vs. Global Contrast Fixes]
+**Learning:** When improving color contrast in a shared design system, modifying global CSS variables (like `--gray-400`) at the root level is high-risk as it can cause regressions in decorative or secondary elements across the entire app. Targeted overrides for specific text elements ensure accessibility without disrupting the broader visual hierarchy.
+**Action:** Prefer applying specific, high-contrast variables (e.g., `--gray-700`) to text-heavy elements while keeping global color tokens stable for decorative use.

--- a/index.html
+++ b/index.html
@@ -337,7 +337,7 @@ a:focus-visible { outline: 3px solid var(--blue); outline-offset: 3px; border-ra
 .spec-cell small {
   display: block; font-size: .6875rem; font-weight: 700;
   letter-spacing: .1em; text-transform: uppercase;
-  color: var(--gray-400); margin-bottom: .375rem;
+  color: var(--gray-700); margin-bottom: .375rem;
 }
 .spec-cell strong {
   font-size: 1rem; font-weight: 600; color: var(--gray-900);
@@ -376,7 +376,7 @@ a:focus-visible { outline: 3px solid var(--blue); outline-offset: 3px; border-ra
 .req-card:hover { box-shadow: var(--shadow-sm); }
 .req-card small {
   font-size: .6875rem; font-weight: 700; letter-spacing: .1em;
-  text-transform: uppercase; color: var(--gray-400); display: block; margin-bottom: .375rem;
+  text-transform: uppercase; color: var(--gray-700); display: block; margin-bottom: .375rem;
 }
 .req-card strong { font-size: .9375rem; font-weight: 600; color: var(--gray-900); }
 
@@ -443,7 +443,7 @@ a:focus-visible { outline: 3px solid var(--blue); outline-offset: 3px; border-ra
 }
 .team-info small {
   font-size: .6875rem; font-weight: 700; letter-spacing: .08em;
-  text-transform: uppercase; color: var(--gray-400); display: block;
+  text-transform: uppercase; color: var(--gray-700); display: block;
 }
 .team-info strong { font-size: .9375rem; font-weight: 600; color: var(--gray-900); }
 


### PR DESCRIPTION
### 💡 What
This PR increases the color contrast for secondary labels (small text) across the "Components", "Requirements", and "Team" sections of the main landing page.

### 🎯 Why
The original design used `--gray-400` (`#9aa0a6`) for these labels, which resulted in a contrast ratio of approximately **2.85:1** against the white background. This falls short of the **WCAG 2.1 AA** requirement of **4.5:1** for small text, making the interface difficult to read for users with visual impairments.

### ♿ Accessibility Improvements
- **Contrast Ratio:** Improved from ~2.85:1 to **4.5:1**.
- **Strategy:** Used "surgical" CSS overrides for specific functional text components. This ensures accessibility compliance without globally darkening the `--gray-400` token, which is still used for decorative or non-text elements where high contrast is less critical.

### 🎨 Visual Polish
The labels now have a more grounded, readable appearance (`var(--gray-700)`) while maintaining the intended visual hierarchy of the section.

### 🧪 Verification
- Verified using a Playwright script (`verify_contrast.py`) that calculates the contrast ratio of live elements via `getComputedStyle`.
- Manual visual inspection of `verification.png` confirms the layout remains clean and professional.
- Logged the architectural decision in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [6159305055654974357](https://jules.google.com/task/6159305055654974357) started by @christopherfoxjr*